### PR TITLE
Strip directives by commenting out rather than omitting

### DIFF
--- a/src/aggregator-ruleng/DirectivesParser.cs
+++ b/src/aggregator-ruleng/DirectivesParser.cs
@@ -103,7 +103,11 @@ namespace aggregator.Engine
 
         internal string GetRuleCode()
         {
-            return string.Join(Environment.NewLine, ruleCode, firstCodeLine, ruleCode.Length - firstCodeLine);
+            StringBuilder sb = new StringBuilder();
+            // Keep directive lines commented out, to maintain source location of rule code for diagnostics.
+            for(int i=0; i<ruleCode.Length; i++)
+               sb.AppendLine(i < firstCodeLine ? $"//{ruleCode[i]}" : ruleCode[i]);
+            return sb.ToString();
         }
 
         // directives

--- a/src/unittests-ruleng/RuleTests.cs
+++ b/src/unittests-ruleng/RuleTests.cs
@@ -22,7 +22,7 @@ namespace unittests_ruleng
     {
         internal static string[] Mince(this string ruleCode)
         {
-            return ruleCode.Split(Environment.NewLine);
+            return ruleCode.Split('\n').Select(line => line.TrimEnd('\r')).ToArray();
         }
     }
 
@@ -350,6 +350,21 @@ return string.Empty;
         }
 
         [Fact]
+        public void Diagnostic_Location_Returned_Correctly()
+        {
+            string ruleCode = @".import=""System.Diagnostics""
+Debug.WriteLine(""test"");
+return string.Empty
+";
+
+            var engine = new RuleEngine(logger, ruleCode.Mince(), SaveMode.Default, dryRun: true);
+            var (success, diagnostics) = engine.VerifyRule();
+            Assert.False(success);
+            Assert.Single(diagnostics);
+            Assert.Equal(2, diagnostics[0].Location.GetLineSpan().StartLinePosition.Line);
+        }
+
+        [Fact]
         public async Task DeleteWorkItem()
         {
             int workItemId = 42;
@@ -487,7 +502,7 @@ return customField;
             witClient.GetWorkItemAsync(workItemId, expand: WorkItemExpand.All).Returns(workItem);
             string ruleCode = @"
 var customField = self.GetFieldValue<decimal>(""MyOrg.CustomNumericField"", 3.0m);
-return customField.ToString(""N"");
+return customField.ToString(""N"", System.Globalization.CultureInfo.InvariantCulture);
 ";
 
             var engine = new RuleEngine(logger, ruleCode.Mince(), SaveMode.Default, dryRun: true);
@@ -512,7 +527,7 @@ return customField.ToString(""N"");
             witClient.GetWorkItemAsync(workItemId, expand: WorkItemExpand.All).Returns(workItem);
             string ruleCode = @"
 var customField = self.GetFieldValue<decimal>(""MyOrg.CustomNumericField"", 3.0m);
-return customField.ToString(""N"");
+return customField.ToString(""N"", System.Globalization.CultureInfo.InvariantCulture);
 ";
 
             var engine = new RuleEngine(logger, ruleCode.Mince(), SaveMode.Default, dryRun: true);


### PR DESCRIPTION
This fixes issue #84 by simply keeping the directive lines in the script source, prefixed with "//", making roslyn Diagnostics point to correct locations.

To get green tests I also did the following small changes in the tests file:

 - Script constant line endings (Unsure if it's my git config causing problems): the test splits by Environment.NewLine, but it's not clear whether the source files will always have newlines that are Environment.NewLine (windows CRLF in my case). A .gitattributes file could maybe help here, but my workaround was simply to split on \n and strip trailing \r  (meaning LF and CRLF both work in the tests).

 - Globalization: the tests assume the system, decimal separator is a dot, failing on e.g. French and Swedish locales where the floating point format is "42,00". Added CultureInfo.InvariantCulture.