### PR TITLE
Fix possible null reference exception

### DIFF
--- a/src/aggregator-ruleng/WorkItemWrapper.cs
+++ b/src/aggregator-ruleng/WorkItemWrapper.cs
@@ -361,7 +361,7 @@ namespace aggregator.Engine
 
             if (_item.Fields.ContainsKey(field))
             {
-                if (_item.Fields[field].Equals(value))
+                if (_item.Fields[field]?.Equals(value) ?? false)
                 {
                     // if new value does not differ from existing value, just ignore change
                     return;

--- a/src/unittests-ruleng/WorkItemWrapperTests.cs
+++ b/src/unittests-ruleng/WorkItemWrapperTests.cs
@@ -4,6 +4,8 @@ using aggregator;
 using aggregator.Engine;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.VisualStudio.Services.WebApi;
+
 using NSubstitute;
 using Xunit;
 
@@ -67,6 +69,31 @@ namespace unittests_ruleng
 
             Assert.False(wrapper.IsDeleted);
             Assert.Equal(RecycleStatus.NoChange, wrapper.RecycleStatus);
+        }
+
+        [Fact]
+        public void AssignFieldWithAlreadyNullValueShouldNotThrowException()
+        {
+            int workItemId = 42;
+            WorkItem workItem = new WorkItem
+                                {
+                                    Id = workItemId,
+                                    Fields = new Dictionary<string, object>
+                                             {
+                                                 { "System.WorkItemType", "Bug" },
+                                                 { "System.Title", "Hello" },
+                                             },
+                                    Url = $"{clientsContext.WorkItemsBaseUrl}/{workItemId}"
+                                };
+
+            var wrapper = new WorkItemWrapper(context, workItem);
+
+            wrapper.AssignedTo = null;
+
+            var idRef = new IdentityRef();
+            wrapper.AssignedTo = idRef;
+
+            Assert.Equal(idRef, wrapper.AssignedTo);
         }
 
 


### PR DESCRIPTION
fixes a possible null ref exception, when a field value with `null` is returned from API

resolved #101 