### PR TITLE
fix adding hyperlinks and filter of non workitem relations

### DIFF
--- a/src/aggregator-ruleng/CoreRelationRefNames.cs
+++ b/src/aggregator-ruleng/CoreRelationRefNames.cs
@@ -5,7 +5,7 @@
         public const string Parent = "System.LinkTypes.Hierarchy-Reverse";
         public const string Children = "System.LinkTypes.Hierarchy-Forward";
         public const string Related = "System.LinkTypes.Related";
-        public const string Hyperlink = "System.LinkTypes.Hyperlink";
+        public const string Hyperlink = "Hyperlink";
         // TODO this is not implemented but should be
         public const string AttachedFile = "AttachedFile";
     }

--- a/src/aggregator-ruleng/WorkItemRelationWrapper.cs
+++ b/src/aggregator-ruleng/WorkItemRelationWrapper.cs
@@ -46,5 +46,11 @@ namespace aggregator.Engine
         public WorkItemId LinkedId { get; }
 
         public IDictionary<string, object> Attributes => _relation.Attributes;
+
+
+        //TODO: quick filter for work item relations only
+        internal static bool IsWorkItemRelation(WorkItemRelation relation) => IsWorkItemRelation(relation.Url);
+        internal static bool IsWorkItemRelation(RelationPatch relationPatch) => IsWorkItemRelation(relationPatch.url);
+        private static bool IsWorkItemRelation(string url) => url?.Contains("/_apis/wit/workItems/", StringComparison.OrdinalIgnoreCase) ?? false;
     }
 }

--- a/src/aggregator-ruleng/WorkItemRelationWrapperCollection.cs
+++ b/src/aggregator-ruleng/WorkItemRelationWrapperCollection.cs
@@ -20,7 +20,8 @@ namespace aggregator.Engine
             _pivotWorkItem = workItem;
             _original = relations == null
                 ? new List<WorkItemRelationWrapper>()
-                : relations.Select(relation => new WorkItemRelationWrapper(relation))
+                : relations.Where(WorkItemRelationWrapper.IsWorkItemRelation)
+                            .Select(relation => new WorkItemRelationWrapper(relation))
                            .ToList();
 
             // do we need deep cloning?

--- a/src/aggregator-ruleng/WorkItemUpdateWrapper.cs
+++ b/src/aggregator-ruleng/WorkItemUpdateWrapper.cs
@@ -19,9 +19,9 @@ namespace aggregator.Engine
 
             Relations = new WorkItemRelationUpdatesWrapper()
                         {
-                            Added   = _workItemUpdate.Relations?.Added?.Select(relation => new WorkItemRelationWrapper(relation)).ToList()   ?? new List<WorkItemRelationWrapper>(),
-                            Removed = _workItemUpdate.Relations?.Removed?.Select(relation => new WorkItemRelationWrapper(relation)).ToList() ?? new List<WorkItemRelationWrapper>(),
-                            Updated = _workItemUpdate.Relations?.Updated?.Select(relation => new WorkItemRelationWrapper(relation)).ToList() ?? new List<WorkItemRelationWrapper>(),
+                            Added   = _workItemUpdate.Relations?.Added?.Where(WorkItemRelationWrapper.IsWorkItemRelation).Select(relation => new WorkItemRelationWrapper(relation)).ToList()   ?? new List<WorkItemRelationWrapper>(),
+                            Removed = _workItemUpdate.Relations?.Removed?.Where(WorkItemRelationWrapper.IsWorkItemRelation).Select(relation => new WorkItemRelationWrapper(relation)).ToList() ?? new List<WorkItemRelationWrapper>(),
+                            Updated = _workItemUpdate.Relations?.Updated?.Where(WorkItemRelationWrapper.IsWorkItemRelation).Select(relation => new WorkItemRelationWrapper(relation)).ToList() ?? new List<WorkItemRelationWrapper>(),
                         };
 
             Fields = _workItemUpdate.Fields?
@@ -33,7 +33,6 @@ namespace aggregator.Engine
                                                   })
                                     ?? new Dictionary<string, WorkItemFieldUpdateWrapper>();
         }
-
 
         /// <summary>ID of update.</summary>
         public int Id => _workItemUpdate.Id;

--- a/src/aggregator-ruleng/WorkItemWrapper.cs
+++ b/src/aggregator-ruleng/WorkItemWrapper.cs
@@ -394,13 +394,17 @@ namespace aggregator.Engine
             switch (value)
             {
                 case IdentityRef id:
-                    {
-                        return id.DisplayName;
-                    }
+                {
+                    return id.DisplayName;
+                }
+                case WorkItemId id:
+                {
+                    return id.Value;
+                }
                 default:
-                    {
-                        return value;
-                    }
+                {
+                    return value;
+                }
             }
         }
 

--- a/src/aggregator-ruleng/WorkItemWrapper.cs
+++ b/src/aggregator-ruleng/WorkItemWrapper.cs
@@ -425,15 +425,16 @@ namespace aggregator.Engine
             Id = new PermanentWorkItemId(newId);
 
             var candidates = Changes.Where(op => op.Path == "/relations/-");
-            foreach (var op in candidates)
+            foreach (var patch in candidates.Select(op => op.Value as RelationPatch).Where(WorkItemRelationWrapper.IsWorkItemRelation))
             {
-                var patch = op.Value as RelationPatch;
-                string url = patch.url;
-                int pos = url.LastIndexOf('/') + 1;
-                int relId = int.Parse(url.Substring(pos));
-                if (relId == oldId)
+                var url = new Uri(patch.url);
+                var idName = url.Segments.Last();
+                var relId = int.TryParse(idName, out var i) ? i : (int?)null;
+                if (relId.HasValue && relId.Value == oldId)
                 {
-                    patch.url = url.Substring(0, pos) + newId.ToString();
+                    //last element is Id
+                    var newUrl = new Uri(url, $"../{newId}");
+                    patch.url = newUrl.ToString();
                     break;
                 }
             }
@@ -444,16 +445,16 @@ namespace aggregator.Engine
         internal void RemapIdReferences(IDictionary<int, int> realIds)
         {
             var candidates = Changes.Where(op => op.Path == "/relations/-");
-            foreach (var op in candidates)
+            foreach (var patch in candidates.Select(op => op.Value as RelationPatch).Where(WorkItemRelationWrapper.IsWorkItemRelation))
             {
-                var patch = op.Value as RelationPatch;
-                string url = patch.url;
-                int pos = url.LastIndexOf('/') + 1;
-                int relId = int.Parse(url.Substring(pos));
-                if (realIds.TryGetValue(relId, out var newId))
+                var url = new Uri(patch.url);
+                var idName = url.Segments.Last();
+                var relId = int.TryParse(idName, out var i) ? i : (int?)null;
+                if (relId.HasValue && realIds.TryGetValue(relId.Value, out var newId))
                 {
-                    string newUrl = url.Substring(0, pos) + newId.ToString();
-                    patch.url = newUrl;
+                    //last element is Id
+                    var newUrl = new Uri(url, $"../{newId}");
+                    patch.url = newUrl.ToString();
                 }
             }
         }


### PR DESCRIPTION
resolves #117

and potentially resolves #114: "Input string was not in a correct format" which can be caused when trying to add a link to a work item which already contains non work item relations (e.g. hyperlink, build, branch etc.) 