### PR TITLE
Github Version Request Response Cache

### DIFF
--- a/src/aggregator-cli/GitHubVersionResponse.cs
+++ b/src/aggregator-cli/GitHubVersionResponse.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.TestManagement.WebApi.Legacy;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace aggregator.cli
+{
+    class GitHubVersionResponse
+    {
+        public const string CacheFileName = "githubresponse.cache";
+        private readonly TimeSpan _cacheExpiration = new TimeSpan(1, 0, 0, 0);
+
+        public string Tag { get; set; }
+        public string Name { get; set; }
+
+        public DateTimeOffset? When { get; set; }
+
+        public string Url { get; set; }
+
+        public DateTime ResponseDate { get; set; }
+
+        public static GitHubVersionResponse TryReadFromCache()
+        {
+            try
+            {
+                if (System.IO.File.Exists(CacheFileName))
+                {
+                    return JsonConvert.DeserializeObject<GitHubVersionResponse>(System.IO.File.ReadAllText(CacheFileName));
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+           
+            
+        }
+
+        public bool CacheIsInDate()
+        {
+            return (DateTime.Now.Subtract(_cacheExpiration) <= ResponseDate);
+        }
+
+        public bool SaveCache()
+        {
+            try
+            {
+                System.IO.File.WriteAllText(CacheFileName, JsonConvert.SerializeObject(this));
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            
+        }
+
+        public static bool ClearCache()
+        {
+            try
+            {
+                System.IO.File.Delete(CacheFileName);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/unittests-core/GitHubVersionResponseTests.cs
+++ b/src/unittests-core/GitHubVersionResponseTests.cs
@@ -1,0 +1,75 @@
+﻿using Xunit;
+using aggregator.cli;
+using System;
+
+namespace unittests_core
+{
+    public class GitHubVersionResponseTests
+    {
+        [Fact]
+        public void GivenAGitHubVersionResponse_WhenCachingTheResponse_ThenACacheFile_ShouldBeSaved()
+        {
+            var responseToCache = new GitHubVersionResponse() 
+            { 
+                Name = "test", 
+                ResponseDate = DateTime.Now, 
+                Tag = "tag", 
+                Url = "url", 
+                When = new DateTimeOffset(DateTime.Now) 
+            };
+
+            responseToCache.SaveCache();
+            var cache = GitHubVersionResponse.TryReadFromCache();
+            var cacheIsEqual = (cache != null &&
+                cache.Name == responseToCache.Name &&
+                cache.ResponseDate == responseToCache.ResponseDate &&
+                cache.Tag == responseToCache.Tag &&
+                cache.Url == responseToCache.Url &&
+                cache.When == responseToCache.When);
+            Assert.True(cacheIsEqual);
+            GitHubVersionResponse.ClearCache();
+        }
+
+        [Fact]
+        public void GivenNoCacheFileExists_WhenAttemptingToReadACacheFrom_ThenANullObject_ShouldBeReturned()
+        {
+            if (System.IO.File.Exists(GitHubVersionResponse.CacheFileName))
+                GitHubVersionResponse.ClearCache();
+
+            var cache = GitHubVersionResponse.TryReadFromCache();
+            Assert.Null(cache);
+        }
+
+        [Fact]
+        public void GivenAGitHubVersionResponseCached_WhenClearingTheCache_ThenTheCacheFile_ShouldBeRemoved()
+        {
+            var responseToCache = new GitHubVersionResponse()
+            {
+                Name = "test",
+                ResponseDate = DateTime.Now,
+                Tag = "tag",
+                Url = "url",
+                When = new DateTimeOffset(DateTime.Now)
+            };
+
+            responseToCache.SaveCache();
+            Assert.True(System.IO.File.Exists(GitHubVersionResponse.CacheFileName));
+            GitHubVersionResponse.ClearCache();
+            Assert.False(System.IO.File.Exists(GitHubVersionResponse.CacheFileName));
+        }
+
+        [Fact]
+        public void GivenAGitHubVersionResponse_WhenReusedWithADay_ThenTheResponse_ShouldBeConsideredValid()
+        {
+            var responseToCache = new GitHubVersionResponse() { Name = "test", ResponseDate = DateTime.Now, Tag = "tag", Url = "url", When = new DateTimeOffset(DateTime.Now) };
+            Assert.True(responseToCache.CacheIsInDate());
+        }
+
+        [Fact]
+        public void GivenAGitHubVersionResponse_WhenReusedAfterADay_ThenTheResponse_ShouldBeConsideredInvalid()
+        {
+            var responseToCache = new GitHubVersionResponse() { Name = "test", ResponseDate = DateTime.Now.Subtract(new TimeSpan(7, 0, 0, 0)), Tag = "tag", Url = "url", When = new DateTimeOffset(DateTime.Now) };
+            Assert.False(responseToCache.CacheIsInDate());
+        }
+    }
+}


### PR DESCRIPTION
Added logic to cache the response received from the github version request to avoid making repeated calls and exceeding the API call limit.

This addresses #131 in the suggested manner of caching the response to disk for a 24 hour period.