### PR TITLE
Add support for .bypassrules directive

### DIFF
--- a/src/aggregator-cli/Rules/AggregatorRules.cs
+++ b/src/aggregator-cli/Rules/AggregatorRules.cs
@@ -164,7 +164,7 @@ namespace aggregator.cli
             if (preprocessedRule.Impersonate)
             {
                 _logger.WriteInfo($"Configure {ruleName} to execute impersonated.");
-                ok &= await ConfigureAsync(instance, ruleName, impersonate: true, cancellationToken: cancellationToken);
+                ok &= await ConfigureAsync(instance, ruleName, impersonate: true, bypassrules: true, cancellationToken: cancellationToken);
                 if (ok)
                 {
                     _logger.WriteInfo($"Updated {ruleName} configuration successfully.");
@@ -339,7 +339,7 @@ namespace aggregator.cli
             return true;
         }
 
-        internal async Task<bool> ConfigureAsync(InstanceName instance, string name, bool? disable = null, bool? impersonate = null, CancellationToken cancellationToken = default)
+        internal async Task<bool> ConfigureAsync(InstanceName instance, string name, bool? disable = null, bool? impersonate = null, bool? bypassrules = null, CancellationToken cancellationToken = default)
         {
             var webFunctionApp = await GetWebApp(instance, cancellationToken);
             var configuration = await AggregatorConfiguration.ReadConfiguration(webFunctionApp);
@@ -353,6 +353,11 @@ namespace aggregator.cli
             if (impersonate.HasValue)
             {
                 ruleConfig.Impersonate = impersonate.Value;
+            }
+
+            if (bypassrules.HasValue)
+            {
+                ruleConfig.BypassRules = impersonate.Value;
             }
 
             ruleConfig.WriteConfiguration(webFunctionApp);
@@ -443,6 +448,7 @@ namespace aggregator.cli
                     {
                         ImpersonateExecution = impersonateExecution
                     };
+                    _logger.WriteVerbose("Test 1");
 
                     var engineLogger = new EngineWrapperLogger(_logger);
                     var engine = new Engine.RuleEngine(engineLogger, saveMode, dryRun: dryRun);

--- a/src/aggregator-cli/Rules/AggregatorRules.cs
+++ b/src/aggregator-cli/Rules/AggregatorRules.cs
@@ -164,7 +164,7 @@ namespace aggregator.cli
             if (preprocessedRule.Impersonate)
             {
                 _logger.WriteInfo($"Configure {ruleName} to execute impersonated.");
-                ok &= await ConfigureAsync(instance, ruleName, impersonate: true, bypassrules: true, cancellationToken: cancellationToken);
+                ok &= await ConfigureAsync(instance, ruleName, impersonate: true, bypassrules: false, cancellationToken: cancellationToken);
                 if (ok)
                 {
                     _logger.WriteInfo($"Updated {ruleName} configuration successfully.");

--- a/src/aggregator-cli/Rules/AggregatorRules.cs
+++ b/src/aggregator-cli/Rules/AggregatorRules.cs
@@ -448,7 +448,6 @@ namespace aggregator.cli
                     {
                         ImpersonateExecution = impersonateExecution
                     };
-                    _logger.WriteVerbose("Test 1");
 
                     var engineLogger = new EngineWrapperLogger(_logger);
                     var engine = new Engine.RuleEngine(engineLogger, saveMode, dryRun: dryRun);

--- a/src/aggregator-cli/Rules/ConfigureRuleCommand.cs
+++ b/src/aggregator-cli/Rules/ConfigureRuleCommand.cs
@@ -44,7 +44,7 @@ namespace aggregator.cli
             var disable = GetDisableStatus(Disable, Enable);
             var impersonate = GetEnableStatus(DisableImpersonateExecution, EnableImpersonateExecution);
 
-            var ok = await rules.ConfigureAsync(instance, Name, disable, impersonate, cancellationToken);
+            var ok = await rules.ConfigureAsync(instance, Name, disable, impersonate, false, cancellationToken);
             return ok ? ExitCodes.Success : ExitCodes.Failure;
         }
 

--- a/src/aggregator-ruleng/IRule.cs
+++ b/src/aggregator-ruleng/IRule.cs
@@ -18,6 +18,13 @@ namespace aggregator.Engine
         /// <remarks>Setter public for CLI</remarks>
         bool ImpersonateExecution { get; set; }
 
+        /// <summary>
+        /// WorkItem creation/updates will bypass rules
+        /// Assumes PAT or Account Permission is high enough
+        /// </summary>
+        /// <remarks>Setter public for CLI</remarks>
+        bool BypassRules { get; set; }
+
         ///<summary>
         /// Configuration data picked by the directive parser that may influence a rule behaviour.
         ///</summary>

--- a/src/aggregator-ruleng/Language/IPreprocessedRule.cs
+++ b/src/aggregator-ruleng/Language/IPreprocessedRule.cs
@@ -5,6 +5,7 @@ namespace aggregator.Engine.Language
 {
     public interface IPreprocessedRule
     {
+        bool BypassRules { get; set; }
         bool Impersonate { get; set; }
         IRuleSettings Settings { get; }
         RuleLanguage Language { get; }

--- a/src/aggregator-ruleng/Language/PreprocessedRule.cs
+++ b/src/aggregator-ruleng/Language/PreprocessedRule.cs
@@ -8,6 +8,7 @@ namespace aggregator.Engine.Language
     {
         public PreprocessedRule()
         {
+            BypassRules = false;
             Impersonate = false;
             Settings = new RuleSettings();
             Language = RuleLanguage.Unknown;
@@ -19,6 +20,8 @@ namespace aggregator.Engine.Language
         }
 
         public bool Impersonate { get; set; }
+
+        public bool BypassRules { get; set; }
 
         public IRuleSettings Settings { get; private set; }
 

--- a/src/aggregator-ruleng/Language/RuleFileParser.cs
+++ b/src/aggregator-ruleng/Language/RuleFileParser.cs
@@ -56,22 +56,16 @@ namespace aggregator.Engine.Language
 
         (IPreprocessedRule preprocessedRule, bool parseSuccess) Parse(string[] ruleCode)
         {
-            logger.WriteVerbose("start Parse");
-
             var directiveLineIndex = 0;
             var preprocessedRule = new PreprocessedRule()
             {
                 Language = RuleLanguage.Csharp
             };
 
-            logger.WriteVerbose("start Parse while");
-
             while (directiveLineIndex < ruleCode.Length
                 && ruleCode[directiveLineIndex].Length > 0
                 && ruleCode[directiveLineIndex][0] == '.')
             {
-                logger.WriteVerbose("inside Parse while");
-
                 string directive = ruleCode[directiveLineIndex][1..];
                 // stop at first '=' or ' '
                 int endVerb = directive.IndexOfAny(new char[] { '=', ' ' });
@@ -95,7 +89,6 @@ namespace aggregator.Engine.Language
             preprocessedRule.RuleCode.AddRange(ruleCode.Skip(preprocessedRule.FirstCodeLine));
 
             var parseSuccessful = !parsingIssues;
-            logger.WriteVerbose("end Parse");
             return (preprocessedRule, parseSuccessful);
 
         }
@@ -130,7 +123,6 @@ namespace aggregator.Engine.Language
                     ParseImpersonateDirective(preprocessedRule, directive, arguments);
                     break;
                 case "bypassrules":
-                    logger.WriteVerbose("bypassrules");
                     ParseBypassRulesDirective(preprocessedRule, directive, arguments);
                     break;
                 case "check":

--- a/src/aggregator-ruleng/RuleEngine.cs
+++ b/src/aggregator-ruleng/RuleEngine.cs
@@ -69,7 +69,7 @@ namespace aggregator.Engine
             var result = await rule.ApplyAsync(executionContext, cancellationToken);
 
             var store = executionContext.store;
-            var (created, updated) = await store.SaveChanges(saveMode, !dryRun, rule.ImpersonateExecution, cancellationToken);
+            var (created, updated) = await store.SaveChanges(saveMode, !dryRun, rule.ImpersonateExecution, rule.BypassRules, cancellationToken);
             if (created + updated > 0)
             {
                 logger.WriteInfo($"Changes saved to Azure DevOps (mode {saveMode}): {created} created, {updated} updated.");

--- a/src/aggregator-ruleng/ScriptedRuleWrapper.cs
+++ b/src/aggregator-ruleng/ScriptedRuleWrapper.cs
@@ -30,6 +30,7 @@ namespace aggregator.Engine
         internal IPreprocessedRule RuleDirectives { get; private set; }
 
         public IRuleSettings Settings { get; private set; }
+        public bool BypassRules { get; set; }
 
         private ScriptedRuleWrapper(string ruleName, IAggregatorLogger logger)
         {
@@ -72,8 +73,11 @@ namespace aggregator.Engine
 
         private void Initialize(IPreprocessedRule preprocessedRule)
         {
+
             RuleDirectives = preprocessedRule;
             ImpersonateExecution = RuleDirectives.Impersonate;
+            BypassRules = RuleDirectives.BypassRules;
+
             Settings = preprocessedRule.Settings;
 
             var references = new HashSet<Assembly>(DefaultAssemblyReferences().Concat(RuleDirectives.LoadAssemblyReferences()));

--- a/src/aggregator-shared/AggregatorConfiguration.cs
+++ b/src/aggregator-shared/AggregatorConfiguration.cs
@@ -39,6 +39,7 @@ namespace aggregator
         string RuleName { get; }
         bool IsDisabled { get; set; }
         bool Impersonate { get; set; }
+        bool BypassRules { get; set; }
     }
 
 
@@ -72,6 +73,11 @@ namespace aggregator
                 if (string.Equals("Impersonate", key, StringComparison.OrdinalIgnoreCase))
                 {
                     ruleConfig.Impersonate = string.Equals("onBehalfOfInitiator", ruleSetting.value, StringComparison.OrdinalIgnoreCase);
+                }
+
+                if (string.Equals("BypassRules", key, StringComparison.OrdinalIgnoreCase))
+                {
+                    ruleConfig.BypassRules = string.Equals("true", ruleSetting.value, StringComparison.OrdinalIgnoreCase);
                 }
             }
 
@@ -156,6 +162,7 @@ namespace aggregator
         {
             settings[$"{RULE_SETTINGS_PREFIX}{ruleSetting.RuleName}.Disabled"] = ruleSetting.IsDisabled.ToString();
             settings[$"{RULE_SETTINGS_PREFIX}{ruleSetting.RuleName}.Impersonate"] = ruleSetting.Impersonate ? "onBehalfOfInitiator" : "false";
+            settings[$"{RULE_SETTINGS_PREFIX}{ruleSetting.RuleName}.BypassRules"] = ruleSetting.BypassRules ? "true" : "false";
         }
 
         private static void ApplyWithAppSettings(this Microsoft.Azure.Management.AppService.Fluent.IWebApp webApp, Dictionary<string, string> settings)

--- a/src/aggregator-shared/Model/RuleConfiguration.cs
+++ b/src/aggregator-shared/Model/RuleConfiguration.cs
@@ -13,5 +13,6 @@ namespace aggregator.Model
         public string RuleName { get; }
         public bool IsDisabled { get; set; }
         public bool Impersonate { get; set; }
+        public bool BypassRules { get; set; }
     }
 }

--- a/src/unittests-ruleng/WorkItemStoreTests.cs
+++ b/src/unittests-ruleng/WorkItemStoreTests.cs
@@ -165,7 +165,7 @@ namespace unittests_ruleng
 
             var wi = sut.NewWorkItem("Task");
             wi.Title = "Brand new";
-            var save = await sut.SaveChanges(SaveMode.Default, false, false, CancellationToken.None);
+            var save = await sut.SaveChanges(SaveMode.Default, false, false, false, CancellationToken.None);
 
             Assert.NotNull(wi);
             Assert.True(wi.IsNew);
@@ -320,7 +320,7 @@ namespace unittests_ruleng
             var wrapper = sut.GetWorkItem(workItemId);
             wrapper.Title = "Replaced title";
 
-            var result = await sut.SaveChanges(SaveMode.Default, commit: true, impersonate: false, default);
+            var result = await sut.SaveChanges(SaveMode.Default, commit: true, impersonate: false, bypassrules: false, default);
 
             Assert.Equal(0, result.created);
             Assert.Equal(1, result.updated);
@@ -362,7 +362,7 @@ namespace unittests_ruleng
             var wrapper = sut.GetWorkItem(workItemId);
             wrapper.Title = "Replaced title";
 
-            var result = await sut.SaveChanges(SaveMode.Default, commit: true, impersonate: false, default);
+            var result = await sut.SaveChanges(SaveMode.Default, commit: true, impersonate: false, bypassrules: false, default);
 
             Assert.Equal(0, result.created);
             Assert.Equal(1, result.updated);


### PR DESCRIPTION
These changes add support for .bypassrules=true directive, to allow for bypassing rules but not requiring impersonation. An example of a need for this would be for updating fields where there are read-only rules in place, such as for calculating a value based on other fields where you don't want users to be able to update the calculated value.

Closes #83.