### PR TITLE
fixed an issue which caused removing work item links to fail

### DIFF
--- a/src/aggregator-ruleng/WorkItemRelationWrapper.cs
+++ b/src/aggregator-ruleng/WorkItemRelationWrapper.cs
@@ -49,7 +49,7 @@ namespace aggregator.Engine
 
         //TODO: quick filter for work item relations only
         internal static bool IsWorkItemRelation(WorkItemRelation relation) => IsWorkItemRelation(relation.Url);
-        internal static bool IsWorkItemRelation(RelationPatch relationPatch) => IsWorkItemRelation(relationPatch.url);
+        internal static bool IsWorkItemRelation(RelationPatch relationPatch) => IsWorkItemRelation(relationPatch?.url);
         private static bool IsWorkItemRelation(string url) => url?.Contains("/_apis/wit/workItems/", StringComparison.OrdinalIgnoreCase) ?? false;
     }
 }

--- a/src/aggregator-ruleng/WorkItemRelationWrapperCollection.cs
+++ b/src/aggregator-ruleng/WorkItemRelationWrapperCollection.cs
@@ -65,8 +65,7 @@ namespace aggregator.Engine
                 _pivotWorkItem.Changes.Add(new JsonPatchOperation()
                 {
                     Operation = Operation.Remove,
-                    Path = "/relations/-",
-                    Value = _original.IndexOf(item)
+                    Path = $"/relations/{_original.IndexOf(item)}"
                 });
                 _pivotWorkItem.IsDirty = true;
                 return true;


### PR DESCRIPTION
This fixes issue #234 

From what I can see, there are two issues:

1) RemapIdReferences calls IsWorkItemRelation, which is expecting a RelationPatch as a value. However - remove link operations previously sent an integer value (i.e. the index of the item being removed). This led to the object reference not set error.

Fixing this issue to tolerate a non RelationPatch value resulted in a new error message which continued to prevent links from being removed.

2) the Remove link operation was previously built up with a Path value of "/relations/-" and a Value of the index to remove. According to the [MS documentation](https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/work%20items/update?view=azure-devops-rest-6.0) this is not correct and the json should be structured as per the below.

[
  {
    "op": "test",
    "path": "/rev",
    "value": 3
  },
  {
    "op": "remove",
    "path": "/relations/2"
  }
]

Making both of the above changes results in the remove operation working as expected.
