### PR TITLE
Fix saving work items when impersonation is enabled

### DIFF
--- a/src/aggregator-ruleng/WorkItemRelationWrapperCollection.cs
+++ b/src/aggregator-ruleng/WorkItemRelationWrapperCollection.cs
@@ -49,8 +49,6 @@ namespace aggregator.Engine
                         : null
                 }
             });
-
-            _pivotWorkItem.IsDirty = true;
         }
 
         private bool RemoveRelation(WorkItemRelationWrapper item)
@@ -68,7 +66,6 @@ namespace aggregator.Engine
                     Path = "/relations/-",
                     Value = _original.IndexOf(item)
                 });
-                _pivotWorkItem.IsDirty = true;
                 return true;
             }
 

--- a/src/aggregator-ruleng/WorkItemStore.cs
+++ b/src/aggregator-ruleng/WorkItemStore.cs
@@ -156,8 +156,7 @@ namespace aggregator.Engine
             foreach (var workItem in changedWorkItems)
             {
                 // emit JsonPatchOperation for this field even if the value is unchanged
-                workItem.ChangedBy = null;
-                workItem.ChangedBy = _triggerIdentity;
+                workItem.ForceSetFieldValue(CoreFieldRefNames.ChangedBy, _triggerIdentity);
             }
         }
 

--- a/src/aggregator-ruleng/WorkItemStore.cs
+++ b/src/aggregator-ruleng/WorkItemStore.cs
@@ -132,7 +132,6 @@ namespace aggregator.Engine
             workItem.RecycleStatus = toRecycleStatus;
 
             var updated = previousStatus != workItem.RecycleStatus;
-            workItem.IsDirty = updated || workItem.IsDirty;
             return updated;
         }
 

--- a/src/aggregator-ruleng/WorkItemWrapper.cs
+++ b/src/aggregator-ruleng/WorkItemWrapper.cs
@@ -345,7 +345,9 @@ namespace aggregator.Engine
 
         public bool IsNew => Id is TemporaryWorkItemId;
 
-        public bool IsDirty { get; internal set; }
+        public bool IsDirty =>
+            RecycleStatus != RecycleStatus.NoChange ||
+            Changes.Any(op => op.Operation != Operation.Test);
 
         internal RecycleStatus RecycleStatus { get; set; } = RecycleStatus.NoChange;
 
@@ -399,7 +401,6 @@ namespace aggregator.Engine
             if (newOp != null)
             {
                 Changes.Add(newOp);
-                IsDirty = true;
             }
         }
 

--- a/src/unittests-ruleng/WorkItemWrapperTests.cs
+++ b/src/unittests-ruleng/WorkItemWrapperTests.cs
@@ -122,6 +122,7 @@ namespace unittests_ruleng
                                              {
                                                  { "System.WorkItemType", "Task" },
                                                  { "System.Title", "The Child" },
+                                                 { CustomField, "Some value" },
                                              },
                 Url = $"{clientsContext.WorkItemsBaseUrl}/{destWorkItemId}"
             };
@@ -166,6 +167,7 @@ namespace unittests_ruleng
                                              {
                                                  { "System.WorkItemType", "Task" },
                                                  { "System.Title", "The Child" },
+                                                 { CustomField, "Some value" },
                                              },
                 Url = $"{clientsContext.WorkItemsBaseUrl}/{destWorkItemId}"
             };
@@ -246,18 +248,9 @@ namespace unittests_ruleng
             };
             var wrapper = new WorkItemWrapper(context, workItem);
 
+            Assert.False(wrapper.IsDirty);
             wrapper[CustomField] = null;
-
-            // first is the /test op
-            Assert.Equal(2, wrapper.Changes.Count);
-            var actual = wrapper.Changes[1];
-            var expected = new JsonPatchOperation
-            {
-                Operation = Operation.Remove,
-                Path = $"/fields/{CustomField}",
-                Value = null
-            };
-            Assert.True(expected.Operation == actual.Operation && expected.Path == actual.Path && expected.Value?.ToString() == actual.Value?.ToString() && expected.From == actual.From);
+            Assert.False(wrapper.IsDirty);
         }
 
         [Fact]

--- a/src/unittests-ruleng/WorkItemWrapperTests.cs
+++ b/src/unittests-ruleng/WorkItemWrapperTests.cs
@@ -397,8 +397,10 @@ namespace unittests_ruleng
             Assert.Equal("Replaced title", actual.Value);
         }
 
-        [Fact]
-        public void ChangingAPulledFieldTwiceHasASingleReplaceOperation()
+        [Theory]
+        [InlineData("Replaced Title")]
+        [InlineData(null)]
+        public void ChangingAPulledFieldTwiceHasASingleReplaceOperation(string firstValue)
         {
             var logger = Substitute.For<IAggregatorLogger>();
             var ruleSettings = new RuleSettings { EnableRevisionCheck = false };
@@ -418,7 +420,7 @@ namespace unittests_ruleng
             };
 
             var wrapper = new WorkItemWrapper(context, workItem);
-            wrapper.Title = "Replaced title";
+            wrapper.Title = firstValue;
             wrapper.Title = "Replaced title - again";
 
             Assert.Single(wrapper.Changes);
@@ -428,8 +430,10 @@ namespace unittests_ruleng
             Assert.Equal("Replaced title - again", actual.Value);
         }
 
-        [Fact]
-        public void ChangingANewFieldTwiceHasASingleAddOperation()
+        [Theory]
+        [InlineData("New Reason")]
+        [InlineData(null)]
+        public void ChangingANewFieldTwiceHasASingleAddOperation(string firstValue)
         {
             var logger = Substitute.For<IAggregatorLogger>();
             var ruleSettings = new RuleSettings { EnableRevisionCheck = false };
@@ -449,7 +453,7 @@ namespace unittests_ruleng
             };
 
             var wrapper = new WorkItemWrapper(context, workItem);
-            wrapper.Reason = "New reason";
+            wrapper.Reason = firstValue;
             wrapper.Reason = "New reason - again";
 
             Assert.Single(wrapper.Changes);


### PR DESCRIPTION
Fixes #229

Updates `WorkItemWrapper` field assignment logic so that repeated assignments of the same fields result in correct values of `Changes` and `IsDirty`. In particular, setting a field to `null` and then to a non-null value will no longer result in emitting a `Remove` operation with a non-null value.