### PR TITLE
Fix IdentyRef parsing

### DIFF
--- a/src/unittests-function/RequestHelperTests.cs
+++ b/src/unittests-function/RequestHelperTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using aggregator;
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.VisualStudio.Services.WebApi;
+using Xunit;
+
+
+namespace unittests_function
+{
+    public class RequestHelperTests
+    {
+        [Fact]
+        public void MigrateIdentityInformationUpdatesIdentityFields()
+        {
+            var logger = NSubstitute.Substitute.For<ILogger>();
+            WorkItem workItem = new WorkItem
+            {
+                Fields = new Dictionary<string, object>
+                {
+                  { "System.WorkItemType", "Bug" },
+                  { "FixedBy", "Jane Doe <jdoe@example.com>" },
+                },
+            };
+
+            new RequestHelper(logger).MigrateIdentityInformation("1.0", workItem);
+
+            var identityValue = workItem.Fields["FixedBy"];
+            Assert.IsType<IdentityRef>(identityValue);
+            Assert.Equal("Jane Doe", ((IdentityRef)identityValue).DisplayName);
+            Assert.Equal("jdoe@example.com", ((IdentityRef)identityValue).UniqueName);
+        }
+
+        [Fact]
+        public void MigrateIdentityInformationDoesNotUpdateStrings()
+        {
+            var logger = NSubstitute.Substitute.For<ILogger>();
+            WorkItem workItem = new WorkItem
+            {
+                Fields = new Dictionary<string, object>
+                {
+                  { "System.WorkItemType", "Bug" },
+                  { "VerifyBy", "GA" },
+                  { "SmileTo", ">_<" },
+                },
+            };
+
+            new RequestHelper(logger).MigrateIdentityInformation("1.0", workItem);
+
+            var stringValue = workItem.Fields["VerifyBy"];
+            Assert.IsType<string>(stringValue);
+            Assert.Equal("GA", stringValue);
+
+            stringValue = workItem.Fields["SmileTo"];
+            Assert.IsType<string>(stringValue);
+            Assert.Equal(">_<", stringValue);
+        }
+    }
+}


### PR DESCRIPTION
Fix an off-by-one error when getting unique name from the string.
Fix invalid cast exception when the IdentityRef could not be parsed. The null-coalescing operator on lines 130 and 134 was trying to cast a string value to `IdentityRef`.
