### PR TITLE
Support "only links" filter option when adding a mapping

### DIFF
--- a/src/aggregator-cli/Mappings/AggregatorMappings.cs
+++ b/src/aggregator-cli/Mappings/AggregatorMappings.cs
@@ -383,6 +383,7 @@ namespace aggregator.cli
         public string Type { get; set; }
         public string Tag { get; set; }
         public IEnumerable<string> Fields { get; set; }
+        public bool OnlyLinks { get; set; }
     }
 
     internal static class EventFiltersExtension
@@ -411,6 +412,11 @@ namespace aggregator.cli
             {
                 // Filter events to include only work items with the specified field(s) changed
                 yield return new KeyValuePair<string, string>("changedFields", string.Join(',', filters.Fields));
+            }
+            if (filters.OnlyLinks)
+            {
+                // Filter events to include only work items with added or removed links
+                yield return new KeyValuePair<string, string>("linksChanged", "true");
             }
         }
 

--- a/src/aggregator-cli/Mappings/MapLocalRuleCommand.cs
+++ b/src/aggregator-cli/Mappings/MapLocalRuleCommand.cs
@@ -38,6 +38,9 @@ namespace aggregator.cli
         [ShowInTelemetry]
         [Option("filterFields", Required = false, HelpText = "Filter Azure DevOps event to include only work items with the specified Field(s) changed.")]
         public IEnumerable<string> FilterFields { get; set; }
+        [ShowInTelemetry]
+        [Option("filterOnlyLinks", Required = false, HelpText = "Filter Azure DevOps event to include only work items with links added or removed.")]
+        public bool FilterOnlyLinks { get; set; }
 
         internal override async Task<int> RunAsync(CancellationToken cancellationToken)
         {
@@ -57,7 +60,8 @@ namespace aggregator.cli
                 AreaPath = FilterAreaPath,
                 Type = FilterType,
                 Tag = FilterTag,
-                Fields = FilterFields
+                Fields = FilterFields,
+                OnlyLinks = FilterOnlyLinks,
             };
 
             var targetUrl = new Uri(TargetUrl);

--- a/src/aggregator-cli/Mappings/MapRuleCommand.cs
+++ b/src/aggregator-cli/Mappings/MapRuleCommand.cs
@@ -42,6 +42,9 @@ namespace aggregator.cli
         [ShowInTelemetry]
         [Option("filterFields", Required = false, HelpText = "Filter Azure DevOps event to include only work items with the specified Field(s) changed.")]
         public IEnumerable<string> FilterFields { get; set; }
+        [ShowInTelemetry]
+        [Option("filterOnlyLinks", Required = false, HelpText = "Filter Azure DevOps event to include only work items with links added or removed.")]
+        public bool FilterOnlyLinks { get; set; }
 
         internal override async Task<int> RunAsync(CancellationToken cancellationToken)
         {
@@ -63,7 +66,8 @@ namespace aggregator.cli
                 AreaPath = FilterAreaPath,
                 Type = FilterType,
                 Tag = FilterTag,
-                Fields = FilterFields
+                Fields = FilterFields,
+                OnlyLinks = FilterOnlyLinks,
             };
 
             var instance = context.Naming.Instance(Instance, ResourceGroup);


### PR DESCRIPTION
Add a command-line flag that sets the "Links are added or removed" filter of the Azure DevOps subscription
![image](https://user-images.githubusercontent.com/50981666/130592166-4de7c801-8ecf-4538-875a-2fcd26f85759.png)

Tested on Azure DevOps Services but not the local server.